### PR TITLE
Add a RAXMON_ prefix to the environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ files are installed.
 
 ## Settings Credentials
 
-Credentials can be set in a configuration file (`~/.raxrc`) or you can pass
-them manually to each command.
+Credentials can be set (in order of precedence) as environment variables (RAXMON_USERNAME,
+RAXMON_API_KEY, RAXMON_API_URL), in a configuration file (~/.raxrc) or you can pass them
+manually to each command.
 
 ### Example configuration file
 

--- a/raxmon_cli/utils.py
+++ b/raxmon_cli/utils.py
@@ -71,9 +71,9 @@ def instance_to_dict(instance, keys, include_none=False):
 
 
 def get_credentials():
-    username = os.getenv('USERNAME', None)
-    api_key = os.getenv('API_KEY', None)
-    api_url = os.getenv('API_URL', None)
+    username = os.getenv('RAXMON_USERNAME', None)
+    api_key = os.getenv('RAXMON_API_KEY', None)
+    api_url = os.getenv('RAXMON_API_URL', None)
 
     config = ConfigParser.ConfigParser()
     config.read(CONFIG_PATH)


### PR DESCRIPTION
Many applications depend on environment variables such as username and api key, so it would be nice if Rackspace Monitoring CLI had it's own prefix, such as RAXMON_USERNAME, RAXMON_API_KEY, RAXMON_API_URL.

The README also needs to be updated, because there is no mention about the precedence (in get_credentials()) of these variables over the ~/.raxmon file. I already had a USERNAME variable set to a value different than the one I needed to use in Rackspace. It took me a while to figure out that it was overriding the settings in ~/.raxrc.
