### PR TITLE
raxmon-entities-agent-test: add

### DIFF
--- a/commands/raxmon-entities-agent-test
+++ b/commands/raxmon-entities-agent-test
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from raxmon_cli.common import run_action
+
+OPTIONS = [
+    [['--id'], {'dest': 'entity_id', 'help': 'Entity ID'}],
+]
+REQUIRED_OPTIONS = ['entity_id']
+
+host_info_types = ['memory', 'cpus', 'network_interfaces', 'system',
+                   'disks', 'filesystems', 'processes']
+
+agent_check_types = ['agent.memory', 'agent.disk', 'agent.memory',
+                     'agent.network', 'agent.cpu']
+
+def callback(driver, options, args, callback):
+    results = []
+
+    en = driver.get_entity(entity_id=options.entity_id)
+
+    results.append(driver.list_agent_connections(agent_id=en.agent_id))
+
+    for c in agent_check_types:
+        result = driver.test_check(entity=en,
+                               monitoring_zones=['mza'],
+                               type=c)
+
+        results.append(result)
+
+    for t in host_info_types:
+        results.append(driver.get_agent_host_info(agent_id=en.agent_id,
+            info_type=t))
+
+    callback(results)
+
+run_action(OPTIONS, REQUIRED_OPTIONS, 'agent_connections', 'list', callback)


### PR DESCRIPTION
raxmon-entities-agent-test will test all of the on demand features of an
agent.
