### PR TITLE
Support for listing metrics for a given entity and check

### DIFF
--- a/commands/raxmon-metrics-list
+++ b/commands/raxmon-metrics-list
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from raxmon_cli.common import run_action
+
+OPTIONS = [
+    [['--entity-id'], {'dest': 'entity_id', 'help': 'Parent Entity id'}],
+    [['--check-id'], {'dest': 'check_id', 'help': 'Check id'}],
+]
+
+REQUIRED_OPTIONS = ['entity_id', 'check_id']
+
+
+def callback(driver, options, args, callback):
+    result = driver.list_metrics(entity_id=options.entity_id,
+        check_id=options.check_id)
+    callback(result)
+
+run_action(OPTIONS, REQUIRED_OPTIONS, 'metrics', 'list', callback)


### PR DESCRIPTION
Here is how the output would look: (The ... part is ugly but consistent with the output produced by other commands) 

lakshmi-desktop in /local/src/rax/rackspace-monitoring-cli$ commands/raxmon-metrics-list --entity-id=enZDETYvQe --check-id=chU3xVPXYr

```
<Metric: name=mzdfw.available ...>
<Metric: name=mzdfw.average ...>
<Metric: name=mzlon.available ...>
<Metric: name=mzlon.average ...>
<Metric: name=mzord.available ...>
<Metric: name=mzord.average ...>

Total: 6
```
