### PR TITLE
Adding requirements.txt + import to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+rackspace-monitoring>= 0.5.0, <= 0.6.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ from distutils.core import setup
 from distutils.core import Command
 from subprocess import call
 from os.path import join as pjoin
+from pip.req import parse_requirements
 
 
 if (sys.version_info < (2, 5, 0) or sys.version_info >= (3, 0, 0)):
@@ -87,7 +88,8 @@ scripts = os.listdir(pjoin(os.getcwd(), 'commands/'))
 scripts = [pjoin(os.getcwd(), 'commands/', path) for path in scripts]
 
 pre_python26 = (sys.version_info[0] == 2 and sys.version_info[1] < 6)
-requires = ['rackspace_monitoring >= 0.5.0, <= 0.6.0']
+
+requires = [str(ir.req) for ir in parse_requirements('requirements.txt')]
 
 if pre_python26:
     requires.append('simplejson')


### PR DESCRIPTION
I moved the requirements to requirements.txt and added an include to the setup.py... also tested an install with pip install -e setup.py which ran the local setup.py... This change allows a user to easily install a local git repo without pip -e specifically(python setup.py + pip install -r requirements.txt.) I believe this makes a requirements.txt part of your documentation, to better define an applications requirements.
