### PR TITLE
Add metadata params to the update commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+rackspace-monitoring-cli v0.6.2 - 2013-03-07:
+
+* Depend on rackspace-monitoring v0.6.1
+* Expose metadata on checks, notifications, and notification plans
+
 rackspace-monitoring-cli v0.6.1 - 2014-03-06:
 
 * Add requirements.txt to MANIFEST

--- a/commands/raxmon-checks-update
+++ b/commands/raxmon-checks-update
@@ -28,7 +28,8 @@ OPTIONS = [
     [['--monitoring-zones'], {'dest': 'monitoring_zones', 'help': 'A list of monitoring zones'}],
     [['--target-alias'], {'dest': 'target_alias', 'help': 'Target alias'}],
     [['--target-hostname'], {'dest': 'target_hostname', 'help': 'Target hostname'}],
-    [['--target-resolver'], {'dest': 'target_resolver', 'help': 'Target resolver'}]
+    [['--target-resolver'], {'dest': 'target_resolver', 'help': 'Target resolver'}],
+    [['--metadata'], {'dest': 'metadata', 'help': 'Check metadata'}],
 ]
 
 REQUIRED_OPTIONS = ['entity_id', 'id']
@@ -36,8 +37,9 @@ REQUIRED_OPTIONS = ['entity_id', 'id']
 def callback(driver, options, args, callback):
     options.monitoring_zones = str_to_list(options.monitoring_zones)
     options.details = str_to_dict(options.details)
+    options.metadata = str_to_dict(options.metadata)
     keys = ['label', 'type', 'details', 'timeout', 'period', 'monitoring_zones',
-            'target_alias', 'target_hostname', 'target_resolver']
+            'target_alias', 'target_hostname', 'target_resolver', 'metadata']
 
     ch = driver.get_check(entity_id=options.entity_id, check_id=options.id)
     data = instance_to_dict(options, keys, False)

--- a/commands/raxmon-notification-plans-update
+++ b/commands/raxmon-notification-plans-update
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from raxmon_cli.common import run_action
-from raxmon_cli.utils import str_to_list, instance_to_dict
+from raxmon_cli.utils import str_to_dict, str_to_list, instance_to_dict
 
 OPTIONS = [
     [['--id'], {'dest': 'id', 'help': 'Notification plan id'}],
@@ -23,6 +23,7 @@ OPTIONS = [
     [['--critical-state'], {'dest': 'critical_state', 'help': 'A list of Notification ids for CRITICAL state'}],
     [['--warning-state'], {'dest': 'warning_state', 'help': 'A list of Notification ids for WARNING state'}],
     [['--ok-state'], {'dest': 'ok_state', 'help': 'A list of Notification ids for OK state'}],
+    [['--metadata'], {'dest': 'metadata', 'help': 'Notification Plan metadata'}],
 ]
 
 REQUIRED_OPTIONS = ['id']
@@ -31,9 +32,10 @@ def callback(driver, options, args, callback):
     options.critical_state = str_to_list(options.critical_state)
     options.warning_state = str_to_list(options.warning_state)
     options.ok_state = str_to_list(options.ok_state)
+    options.metadata = str_to_dict(options.metadata)
 
     np = driver.get_notification_plan(notification_plan_id=options.id)
-    keys = ['label', 'critical_state', 'warning_state', 'ok_state']
+    keys = ['label', 'critical_state', 'warning_state', 'ok_state', 'metadata']
     data = instance_to_dict(options, keys, False)
     result = driver.update_notification_plan(notification_plan=np, data=data,
                                              who=options.who,

--- a/commands/raxmon-notifications-update
+++ b/commands/raxmon-notifications-update
@@ -22,15 +22,17 @@ OPTIONS = [
     [['--label'], {'dest': 'label', 'help': 'Notification label'}],
     [['--type'], {'dest': 'type', 'help': 'Notification type'}],
     [['--details'], {'dest': 'details', 'help': 'Notification details'}],
+    [['--metadata'], {'dest': 'metadata', 'help': 'Notification metadata'}],
 ]
 
 REQUIRED_OPTIONS = ['id']
 
 def callback(driver, options, args, callback):
     options.details = str_to_dict(options.details)
+    options.metadata = str_to_dict(options.metadata)
     no = driver.get_notification(notification_id=options.id)
 
-    data = instance_to_dict(options, ['label', 'type', 'details'], False)
+    data = instance_to_dict(options, ['label', 'type', 'details', 'metadata'], False)
     result = driver.update_notification(notification=no, data=data,
                                         who=options.who,
                                         why=options.why)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-rackspace-monitoring>= 0.6.0
+rackspace-monitoring>= 0.6.1
+


### PR DESCRIPTION
For checks, notifications, and notification-plans (alarms already had it)

This requires: https://github.com/racker/rackspace-monitoring/pull/38
