### PR TITLE
Adding --id flag to alarms, checks and entities

### DIFF
--- a/commands/raxmon-alarms-list
+++ b/commands/raxmon-alarms-list
@@ -18,12 +18,18 @@ from raxmon_cli.common import run_action
 
 OPTIONS = [
     [['--entity-id'], {'dest': 'entity_id', 'help': 'Parent Entity id'}],
+    [['--id'], {'help': 'Alarm id, optionally filter by alarm id'}]
 ]
 
 REQUIRED_OPTIONS = ['entity_id']
 
 def callback(driver, options, args, callback):
     en = driver.get_entity(entity_id=options.entity_id)
-    callback(driver.list_alarms(entity=en, ex_next_marker=options.marker))
+    if options.id:
+        alarm = driver.get_alarm(en.id, options.id)
+        callback([alarm])
+    else:
+        callback(driver.list_alarms(entity=en,
+                                    ex_next_marker=options.marker))
 
 run_action(OPTIONS, REQUIRED_OPTIONS, 'alarms', 'list', callback)

--- a/commands/raxmon-checks-list
+++ b/commands/raxmon-checks-list
@@ -18,12 +18,18 @@ from raxmon_cli.common import run_action
 
 OPTIONS = [
     [['--entity-id'], {'dest': 'entity_id', 'help': 'Parent Entity id'}],
+    [['--id'], {'help': 'Alarm id, optionally filter by check id'}]
 ]
 
 REQUIRED_OPTIONS = ['entity_id']
 
 def callback(driver, options, args, callback):
     en = driver.get_entity(entity_id=options.entity_id)
-    callback(driver.list_checks(entity=en, ex_next_marker=options.marker))
+    if options.id:
+        check = driver.get_check(en.id, options.id)
+        callback([check])
+    else:
+        callback(driver.list_checks(entity=en,
+                                    ex_next_marker=options.marker))
 
 run_action(OPTIONS, REQUIRED_OPTIONS, 'checks', 'list', callback)

--- a/commands/raxmon-entities-list
+++ b/commands/raxmon-entities-list
@@ -17,7 +17,16 @@
 
 from raxmon_cli.common import run_action
 
-def callback(driver, options, args, callback):
-    callback(driver.list_entities(ex_next_marker=options.marker))
+OPTIONS = [
+    [['--id'], {'dest': 'id', 'help': 'Select only Entity id'}],
+]
 
-run_action(None, None, 'entities', 'list', callback)
+
+def callback(driver, options, args, callback):
+    if options.id:
+        entity = driver.get_entity(options.id)
+        callback([entity])
+    else:
+        callback(driver.list_entities(ex_next_marker=options.marker))
+
+run_action(OPTIONS, None, 'entities', 'list', callback)


### PR DESCRIPTION
## Reasoning

I am seeing more users with enough entries to make listing --details quite long. Adding a --id flag allows me to list all objects, pick one and then list the details for that object. It also pairs nicely with the update and delete methods.

I felt adding the id field was better than providing a new command raxmon-object-get.

Example usage: 
raxmon-checks-list  --user USERNAME --api-key ****\* --entity-id enXXXXXXXX --id chXXXXXXXX
