### PR TITLE
Small typo: misspelling fix ('cteate' -> 'create')

### DIFF
--- a/commands/raxmon-checks-test
+++ b/commands/raxmon-checks-test
@@ -55,4 +55,4 @@ def callback(driver, options, args, callback):
 
     print(result)
 
-run_action(OPTIONS, REQUIRED_OPTIONS, 'checks', 'cteate', callback)
+run_action(OPTIONS, REQUIRED_OPTIONS, 'checks', 'create', callback)


### PR DESCRIPTION
I'm think that's supposed to be "create".
