### PR TITLE
fix(check commands): Make sure to always pass an array when creating or updating an agent.plugin check.

### DIFF
--- a/commands/raxmon-checks-create
+++ b/commands/raxmon-checks-create
@@ -37,8 +37,8 @@ def callback(driver, options, args, callback):
     options.details = str_to_dict(options.details)
 
     if options.type == 'agent.plugin':
-        if options.details.args and !isinstance(options.details.args, list):
-            options.details.args = [options.details.args]
+        if options.details.get('args') and not isinstance(options.details['args'], list):
+            options.details['args'] = [options.details['args']]
 
     en = driver.get_entity(entity_id=options.entity_id)
     result = driver.create_check(label=options.label, timeout=options.timeout,

--- a/commands/raxmon-checks-update
+++ b/commands/raxmon-checks-update
@@ -42,8 +42,8 @@ def callback(driver, options, args, callback):
     ch = driver.get_check(entity_id=options.entity_id, check_id=options.id)
 
     if ch.type == 'agent.plugin':
-        if options.details.args and !isinstance(options.details.args, list):
-            options.details.args = [options.details.args]
+        if options.details.get('args') and not isinstance(options.details['args'], list):
+            options.details['args'] = [options.details['args']]
 
     data = instance_to_dict(options, keys, False)
     result = driver.update_check(check=ch, data=data)


### PR DESCRIPTION
When creating and updating `agent.plugin` checks, you have to pass the `args` field as an array. #69 fixed things by allowing arrays to be specified, but it doesn't have any way  of knowing that args _always_ has to be an array, even if only a single arg is specified. This updates the commands to coerce the field to a list if it isn't one.
