### PR TITLE
Bump version to use rackspace-monitoring 0.6.4

### DIFF
--- a/raxmon_cli/__init__.py
+++ b/raxmon_cli/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.6.4'
+__version__ = '0.6.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rackspace-monitoring>= 0.6.0
+rackspace-monitoring>= 0.6.4


### PR DESCRIPTION
0.6.4 and greater CLI needs 0.6.4 library for host info types support
