### PR TITLE
fix help message for --api-url to not include tenant id

### DIFF
--- a/raxmon_cli/constants.py
+++ b/raxmon_cli/constants.py
@@ -29,7 +29,7 @@ CONFIG_PATH = pjoin(expanduser('~'), CREDENTIALS_FILE)
 
 USERNAME = [['--username'], {'dest': 'username', 'help': 'API username'}]
 API_KEY = [['--api-key'], {'dest': 'api_key', 'help': 'API key'}]
-API_URL = [['--api-url'], {'dest': 'api_url', 'help': 'API URL including the' +
+API_URL = [['--api-url'], {'dest': 'api_url', 'help': 'API URL excluding the ' +
                                                       'tenant id'}]
 AUTH_URL = [['--auth-url'], {'dest': 'auth_url', 'help': 'Auth URL'}]
 


### PR DESCRIPTION
The help message for --api-url states "including the tenant id" but raxmon seems to fetch the tenant id from the auth call and appends it to the --api-url, hence causing a failure if the tenant id was supplied in the api-url.
