### PR TITLE
Exit 1 when CLI encounters stack trace

### DIFF
--- a/raxmon_cli/common.py
+++ b/raxmon_cli/common.py
@@ -130,6 +130,7 @@ def run_action(cmd_options, required_options, resource, action, callback):
         callback(instance, options, args, done)
     except Exception:
         traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
 
 
 def get_instance(username, api_key, url, auth_url=None, auth_token=None):


### PR DESCRIPTION
The raxmon-* CLI tools do not set exit code when you hit an exception.
This commit does a sys.exist(1) when an exception is encountered.