### PR TITLE
add lshw to the options text

### DIFF
--- a/commands/raxmon-agent-host-info
+++ b/commands/raxmon-agent-host-info
@@ -19,7 +19,7 @@ from raxmon_cli.common import run_action
 OPTIONS = [
     [['--agent-id'], {'dest': 'agent_id', 'help': 'Agent ID'}],
     [['--type'], {'dest': 'type', 'help': 'Info Type (memory, cpus, ' +
-      'network_interfaces, system, disks, filesystems, processes)'}],
+      'lshw, network_interfaces, system, disks, filesystems, processes)'}],
 ]
 
 REQUIRED_OPTIONS = ['agent_id', 'type']

--- a/commands/raxmon-entities-host-info
+++ b/commands/raxmon-entities-host-info
@@ -19,7 +19,7 @@ from raxmon_cli.common import run_action
 OPTIONS = [
     [['--entity-id'], {'dest': 'entity_id', 'help': 'Entity ID'}],
     [['--type'], {'dest': 'type', 'help': 'Info Type (memory, cpus, ' +
-      'network_interfaces, system, disks, filesystems, processes)'}],
+      'lshw, network_interfaces, system, disks, filesystems, processes)'}],
 ]
 
 REQUIRED_OPTIONS = ['entity_id', 'type']


### PR DESCRIPTION
This PR simply adds the lshw to the options text to match functionality  added to the rackspace-monitoring-agent via pr:
      https://github.com/virgo-agent-toolkit/rackspace-monitoring-agent/pull/950