### PR TITLE
Added missing why and who option

### DIFF
--- a/commands/raxmon-checks-update
+++ b/commands/raxmon-checks-update
@@ -46,7 +46,9 @@ def callback(driver, options, args, callback):
             options.details['args'] = [options.details['args']]
 
     data = instance_to_dict(options, keys, False)
-    result = driver.update_check(check=ch, data=data)
+    result = driver.update_check(check=ch, data=data,
+                                 who=options.who,
+                                 why=options.why)
     callback(result)
 
 run_action(OPTIONS, REQUIRED_OPTIONS, 'checks', 'update', callback)


### PR DESCRIPTION
raxmon-checks-update ignored the options --why and --who although they
showed up in the help. All other functions already implemented this
feature, it was just missing here.