### PR TITLE
Use system CA certs bundle if it exists

### DIFF
--- a/raxmon_cli/common.py
+++ b/raxmon_cli/common.py
@@ -32,7 +32,7 @@ from libcloud import _init_once
 
 CA_CERT_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'data/cacert.pem')
-libcloud.security.CA_CERTS_PATH.insert(0, CA_CERT_PATH)
+libcloud.security.CA_CERTS_PATH.append(CA_CERT_PATH)
 
 from raxmon_cli.constants import GLOBAL_OPTIONS, ACTION_OPTIONS
 from raxmon_cli.printers import print_list, print_error, print_success


### PR DESCRIPTION
libcloud seems to take the first CA_CERT_PATH that it finds.  This commit
appends data/cacert.pem from the repo instead of inserting it.  This let's us
default to the system CA certs and only use the CA bundle from this repo
if we don't find one of the libcloud defaults.  This allows a deployer
to manage internal CA certs using native distro tools (e.g.
update-ca-certificates).

Closes: https://github.com/racker/rackspace-monitoring-cli/issues/85