### PR TITLE
add parens to print for python3

### DIFF
--- a/commands/raxmon
+++ b/commands/raxmon
@@ -24,7 +24,7 @@ def list_available_commands():
              file.startswith('raxmon-') and file != 'raxmon']
     files = sorted(files)
 
-    print 'Rackspace Monitoring Command Line Tool v%s' % (__version__)
+    print('Rackspace Monitoring Command Line Tool v%s' % (__version__))
     print('Available commands:\n')
     for file in files:
         print('- %s' % (file))

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ class Pep8Command(Command):
             import pep8
             pep8
         except ImportError:
-            print 'Missing "pep8" library. You can install it using pip: ' + \
-                  'pip install pep8'
+            print('Missing "pep8" library. You can install it using pip: ' + \
+                  'pip install pep8')
             sys.exit(1)
 
         cwd = os.getcwd()


### PR DESCRIPTION
there was already a mixture of `print` and `print()` statements, this
change adds parentheses to two print statements so it works with python3
